### PR TITLE
fix(build): Resolve missing dependency by adding AquaAvgFramework submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/AquaAvgFramework"]
+	path = external/AquaAvgFramework
+	url = https://github.com/Project-MethodBox/AquaAvgFramework.git

--- a/README.md
+++ b/README.md
@@ -22,11 +22,31 @@ ReciteHelper 承诺永久保持开源、免费的性质。如果您感觉该项�
 
 ---
 
-## 如何运行
+## 快速开始
 
-1. 环境依赖：需安装 .NET 10 及以上运行环境。
-2. 下载项目源码或者直接下载发行版。
-3. 启动主程序，按界面提示导入 PDF 学习资料，创建项目后即可体验全部功能。
+### 普通用户
+1. 前往 [Releases](https://github.com/ArabidopsisDev/ReciteHelper/releases) 页面下载最新版本。
+2. 解压并运行 `ReciteHelper.exe`。
+3. 按界面提示导入 PDF 学习资料，创建项目后即可体验全部功能。
+
+### 开发者构建
+1. **环境依赖**：需安装 .NET 10 SDK。
+2. **获取源码**：
+   本项目包含子模块，请使用递归克隆：
+   ```bash
+   git clone --recurse-submodules https://github.com/ArabidopsisDev/ReciteHelper.git
+   ```
+   如果已经克隆了仓库，请初始化子模块：
+   ```bash
+   git submodule update --init --recursive
+   ```
+3. **编译运行**：
+   - 使用 JetBrains Rider 或 Visual Studio 打开 `src/ReciteHelper.slnx`。
+   - 或者使用命令行：
+     ```bash
+     dotnet restore
+     dotnet run --project src/ReciteHelper.csproj
+     ```
 
 具体使用方法，请参考**用户手册**。
 

--- a/src/ReciteHelper.csproj
+++ b/src/ReciteHelper.csproj
@@ -172,9 +172,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="AquaAvgFramework">
-      <HintPath>..\..\..\..\..\刘\source\repos\AquaAvgFramework\bin\Release\net10.0-windows7.0\AquaAvgFramework.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\external\AquaAvgFramework\AquaAvgFramework.csproj" />
   </ItemGroup>
 
     <Target Name="EnsureJiebaResources" BeforeTargets="Build">

--- a/src/ReciteHelper.slnx
+++ b/src/ReciteHelper.slnx
@@ -1,3 +1,4 @@
 <Solution>
   <Project Path="ReciteHelper.csproj" />
+  <Project Path="..\external\AquaAvgFramework\AquaAvgFramework.csproj" />
 </Solution>

--- a/src/global.json
+++ b/src/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": true
+  }
+}


### PR DESCRIPTION
- Add AquaAvgFramework as a git submodule to external/AquaAvgFramework.

- Update ReciteHelper.csproj and slnx to reference the submodule project.

- Add src/global.json to lock .NET SDK version to 10.0.

- Update README.md with detailed developer build instructions and quick start guide.